### PR TITLE
Add browser-based Snake game implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Snakegame
-Classical snake game
+
+A classical implementation of the Snake arcade game built with HTML5 Canvas and vanilla JavaScript.
+
+## Playing the game
+
+Open `index.html` in a modern browser or serve the repository with any static file server, for example:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit <http://localhost:8000>.
+
+### Controls
+
+- **Arrow keys** or **WASD** — move the snake
+- **Space** — pause or resume the game
+- **Restart button** — start a new round after a game over
+
+Eat as many apples as possible without running into the walls or yourself. Each apple increases the score and slightly increases the snake's speed.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snake Game</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="game-container">
+      <h1>Snake</h1>
+      <canvas id="game" width="400" height="400" aria-label="Snake game board" role="application"></canvas>
+      <div class="hud">
+        <div class="score" aria-live="polite">
+          Score: <span id="score">0</span>
+        </div>
+        <button id="restart" type="button">Restart</button>
+        <div class="instructions">
+          Use arrow keys or WASD to move. Press space to pause.
+        </div>
+      </div>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,197 @@
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+const scoreEl = document.getElementById("score");
+const restartButton = document.getElementById("restart");
+
+const gridSize = 20;
+const tileSize = canvas.width / gridSize;
+const baseSpeed = 10; // moves per second
+
+let snake;
+let direction;
+let nextDirection;
+let apple;
+let score;
+let speed;
+let lastUpdate = 0;
+let isPaused = false;
+let isGameOver = false;
+
+function init() {
+  snake = [
+    { x: Math.floor(gridSize / 2), y: Math.floor(gridSize / 2) },
+    { x: Math.floor(gridSize / 2) - 1, y: Math.floor(gridSize / 2) },
+  ];
+  direction = { x: 1, y: 0 };
+  nextDirection = { ...direction };
+  apple = spawnApple();
+  score = 0;
+  speed = baseSpeed;
+  scoreEl.textContent = score;
+  lastUpdate = 0;
+  isPaused = false;
+  isGameOver = false;
+}
+
+function spawnApple() {
+  let position;
+  do {
+    position = {
+      x: Math.floor(Math.random() * gridSize),
+      y: Math.floor(Math.random() * gridSize),
+    };
+  } while (snake.some((segment) => segment.x === position.x && segment.y === position.y));
+  return position;
+}
+
+function update() {
+  if (isPaused || isGameOver) {
+    return;
+  }
+
+  direction = nextDirection;
+  const head = {
+    x: snake[0].x + direction.x,
+    y: snake[0].y + direction.y,
+  };
+
+  if (
+    head.x < 0 ||
+    head.y < 0 ||
+    head.x >= gridSize ||
+    head.y >= gridSize ||
+    snake.some((segment) => segment.x === head.x && segment.y === head.y)
+  ) {
+    isGameOver = true;
+    return;
+  }
+
+  snake.unshift(head);
+
+  if (head.x === apple.x && head.y === apple.y) {
+    score += 10;
+    speed = baseSpeed + Math.floor(score / 50);
+    apple = spawnApple();
+    scoreEl.textContent = score;
+  } else {
+    snake.pop();
+  }
+}
+
+function draw() {
+  ctx.fillStyle = "#050505";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.05)";
+  for (let i = 0; i <= gridSize; i++) {
+    ctx.beginPath();
+    ctx.moveTo(i * tileSize, 0);
+    ctx.lineTo(i * tileSize, canvas.height);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, i * tileSize);
+    ctx.lineTo(canvas.width, i * tileSize);
+    ctx.stroke();
+  }
+
+  const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+  gradient.addColorStop(0, "#38ef7d");
+  gradient.addColorStop(1, "#11998e");
+  ctx.fillStyle = gradient;
+  for (const segment of snake) {
+    ctx.fillRect(
+      segment.x * tileSize + 1,
+      segment.y * tileSize + 1,
+      tileSize - 2,
+      tileSize - 2
+    );
+  }
+
+  ctx.fillStyle = "#ff4757";
+  ctx.beginPath();
+  const appleCenterX = apple.x * tileSize + tileSize / 2;
+  const appleCenterY = apple.y * tileSize + tileSize / 2;
+  const appleRadius = (tileSize - 6) / 2;
+  ctx.arc(appleCenterX, appleCenterY, appleRadius, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (isGameOver) {
+    drawOverlay("Game Over", "Press Restart to play again");
+  } else if (isPaused) {
+    drawOverlay("Paused", "Press space to continue");
+  }
+}
+
+function drawOverlay(title, subtitle) {
+  ctx.fillStyle = "rgba(0, 0, 0, 0.65)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "bold 32px 'Segoe UI', sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(title, canvas.width / 2, canvas.height / 2 - 10);
+
+  ctx.font = "16px 'Segoe UI', sans-serif";
+  ctx.fillText(subtitle, canvas.width / 2, canvas.height / 2 + 20);
+}
+
+function gameLoop(timestamp) {
+  requestAnimationFrame(gameLoop);
+  if (!lastUpdate) {
+    lastUpdate = timestamp;
+  }
+  const delta = timestamp - lastUpdate;
+  const threshold = 1000 / speed;
+  if (delta > threshold) {
+    lastUpdate = timestamp - (delta % threshold);
+    update();
+    draw();
+  }
+}
+
+function handleInput(event) {
+  const key = event.code;
+
+  if (key === "Space") {
+    if (!isGameOver) {
+      isPaused = !isPaused;
+    }
+    event.preventDefault();
+    return;
+  }
+
+  const controls = {
+    ArrowUp: { x: 0, y: -1 },
+    KeyW: { x: 0, y: -1 },
+    ArrowDown: { x: 0, y: 1 },
+    KeyS: { x: 0, y: 1 },
+    ArrowLeft: { x: -1, y: 0 },
+    KeyA: { x: -1, y: 0 },
+    ArrowRight: { x: 1, y: 0 },
+    KeyD: { x: 1, y: 0 },
+  };
+
+  const newDirection = controls[key];
+  if (!newDirection) {
+    return;
+  }
+
+  if (snake.length > 1 && newDirection.x === -direction.x && newDirection.y === -direction.y) {
+    return;
+  }
+
+  nextDirection = newDirection;
+  isPaused = false;
+  event.preventDefault();
+}
+
+restartButton.addEventListener("click", () => {
+  init();
+  draw();
+});
+
+document.addEventListener("keydown", handleInput);
+
+init();
+draw();
+requestAnimationFrame(gameLoop);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,87 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #111;
+  color: #f0f0f0;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.game-container {
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(145deg, #1d1d1d, #111111);
+  box-shadow: 10px 10px 30px rgba(0, 0, 0, 0.5), -10px -10px 30px rgba(60, 60, 60, 0.05);
+  max-width: 480px;
+  width: 100%;
+}
+
+h1 {
+  margin-top: 0;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+canvas {
+  display: block;
+  margin: 0 auto 1rem;
+  border-radius: 0.5rem;
+  background-color: #000;
+  box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.6);
+}
+
+.hud {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.score {
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
+#restart {
+  padding: 0.5rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: #19a974;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+#restart:hover,
+#restart:focus {
+  background: #1fd08d;
+  transform: translateY(-1px);
+}
+
+#restart:active {
+  transform: translateY(1px);
+}
+
+.instructions {
+  font-size: 0.9rem;
+  color: #bfbfbf;
+}
+
+@media (max-width: 480px) {
+  .game-container {
+    border-radius: 0;
+    min-height: 100vh;
+    justify-content: center;
+  }
+
+  canvas {
+    width: 90vw;
+    height: 90vw;
+  }
+}


### PR DESCRIPTION
## Summary
- add an HTML entry point with canvas, score display, and restart control for the classic Snake game
- implement the Snake gameplay loop, controls, and rendering using vanilla JavaScript
- style the game board and interface with a responsive dark theme and document usage in the README

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68e4df936c888326bea161844f2fa047