### PR TITLE
Add Dire Straits-inspired sentence generation service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# Snakegame
-Classical snake game
+# Dire Straits Identity Forge
+
+This project provides a lightweight service that helps you craft original
+sentences inspired by Dire Straits' lyrical universe. Because the band's lyrics
+are copyrighted we do not ship the corpus directly. Instead, the repository
+contains utilities to ingest lyrics that you collected yourself and to generate
+new sentences that highlight the group's characteristic storytelling, nautical
+imagery, and road-weary tone.
+
+## Project layout
+
+```
+.
+├── app.py                   # FastAPI application exposing /ingest and /generate
+├── requirements.txt         # Runtime dependencies
+└── src/
+    └── lyrics_service/
+        ├── corpus_loader.py       # Helpers to load local lyric files
+        ├── sentence_generator.py  # Markov-chain-based generator
+        └── service.py             # High level orchestration façade
+```
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Collect the lyrics**
+
+   Place your legally obtained Dire Straits lyrics in a folder. The loader
+   accepts `.txt`, `.json` and `.csv` files. You can organise the files in any
+   nested directory structure.
+
+3. **Start the service**
+
+   ```bash
+   uvicorn app:app --reload
+   ```
+
+4. **Ingest the lyrics**
+
+   ```bash
+   curl -X POST http://localhost:8000/ingest -H "Content-Type: application/json" \
+        -d '{"directory": "path/to/your/lyrics"}'
+   ```
+
+5. **Generate new sentences**
+
+   ```bash
+   curl -X POST http://localhost:8000/generate -H "Content-Type: application/json" \
+        -d '{"count": 3}'
+   ```
+
+   The service responds with an array of freshly generated sentences and, when
+   available, the song titles inferred from the corpus.
+
+## Running tests
+
+```bash
+pytest
+```
+
+## Notes on lyric usage
+
+Please make sure that you comply with copyright law when collecting and storing
+lyrics. The generator is designed to produce short, original phrases that evoke
+Dire Straits' identity without reproducing the original texts verbatim.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+"""Run the Dire Straits identity sentence generation service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from src.lyrics_service.service import DireStraitsIdentityService
+
+app = FastAPI(title="Dire Straits Identity Forge")
+service = DireStraitsIdentityService()
+
+
+class IngestRequest(BaseModel):
+    directory: str
+
+
+class GenerateRequest(BaseModel):
+    count: int = 1
+    seed: int | None = None
+
+
+class GenerateResponse(BaseModel):
+    sentences: List[str]
+    songs: List[str]
+
+
+@app.post("/ingest")
+def ingest(request: IngestRequest) -> dict[str, str]:
+    try:
+        service.ingest(Path(request.directory))
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"Directory not found: {exc}")
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+
+@app.post("/generate", response_model=GenerateResponse)
+def generate(request: GenerateRequest) -> GenerateResponse:
+    if not service.ready():
+        raise HTTPException(status_code=409, detail="Service not ready. Call /ingest first.")
+
+    try:
+        sentences = service.generate(count=request.count, seed=request.seed)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    songs = service.corpus.songs if service.corpus else []
+    return GenerateResponse(sentences=sentences, songs=songs)
+
+
+__all__ = ["app", "service"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.100
+uvicorn[standard]>=0.23
+pydantic>=1.10
+pytest>=7.4

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Source package for the Dire Straits Identity Forge service."""

--- a/src/lyrics_service/__init__.py
+++ b/src/lyrics_service/__init__.py
@@ -1,0 +1,14 @@
+"""Utilities to build Dire Straits inspired text generation services."""
+
+from .corpus_loader import Corpus, load_corpus
+from .sentence_generator import MarkovModel, build_markov_model, generate_sentence
+from .service import DireStraitsIdentityService
+
+__all__ = [
+    "Corpus",
+    "load_corpus",
+    "MarkovModel",
+    "build_markov_model",
+    "generate_sentence",
+    "DireStraitsIdentityService",
+]

--- a/src/lyrics_service/corpus_loader.py
+++ b/src/lyrics_service/corpus_loader.py
@@ -1,0 +1,148 @@
+"""Utilities for loading and normalising Dire Straits lyric corpora.
+
+The loader is intentionally flexible: it can read raw text files, JSON
+collections or even CSV exports.  The goal of the module is to aggregate the
+lyrics into one clean block of text that can be consumed by the sentence
+generator.
+
+Because we cannot ship the copyrighted lyrics as part of the repository, the
+loader focuses on providing helpers to ingest lyrics that the user collected on
+their own.  In addition, it offers lightweight pre-processing helpers that aim
+at keeping stylistic markers (nautical imagery, references to the road, etc.)
+which are key to Dire Straits' identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+import json
+import re
+
+
+DEFAULT_EXTENSIONS = {".txt", ".json", ".csv"}
+
+
+@dataclass
+class Corpus:
+    """Container returned by :func:`load_corpus`.
+
+    Attributes
+    ----------
+    songs:
+        A list of song titles.
+    text:
+        The aggregated and lightly normalised corpus.
+    """
+
+    songs: List[str]
+    text: str
+
+
+def _normalise_whitespace(text: str) -> str:
+    """Collapse redundant whitespace while keeping stanza separation."""
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines)
+
+
+def _load_text_file(path: Path) -> str:
+    with path.open("r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _load_json_file(path: Path) -> str:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if isinstance(payload, dict):
+        candidates: Iterable[str] = payload.values()
+    elif isinstance(payload, list):
+        candidates = payload
+    else:
+        raise TypeError("Unsupported JSON structure for lyrics corpus")
+
+    collected: List[str] = []
+    for value in candidates:
+        if isinstance(value, str):
+            collected.append(value)
+        elif isinstance(value, dict):
+            collected.extend(str(v) for v in value.values())
+        else:
+            collected.append(str(value))
+    return "\n".join(collected)
+
+
+def _load_csv_file(path: Path) -> str:
+    with path.open("r", encoding="utf-8") as handle:
+        rows = handle.read().splitlines()
+
+    if not rows:
+        return ""
+
+    # Skip header if present
+    if "," in rows[0]:
+        rows = rows[1:]
+    return "\n".join(rows)
+
+
+def _collect_songs_from_text(text: str) -> List[str]:
+    """Best-effort extraction of song titles from inline metadata."""
+
+    song_pattern = re.compile(r"^\s*(?:#|title:)(?P<title>.+)$", re.IGNORECASE)
+    songs = []
+    for line in text.splitlines():
+        match = song_pattern.match(line)
+        if match:
+            songs.append(match.group("title").strip())
+    return songs
+
+
+def load_corpus(
+    directory: Path,
+    extensions: Sequence[str] | None = None,
+) -> Corpus:
+    """Load every lyric file contained in *directory*.
+
+    Parameters
+    ----------
+    directory:
+        Path to a folder containing the lyric files.
+    extensions:
+        Optional whitelist of file extensions.  If omitted the loader falls back
+        to :data:`DEFAULT_EXTENSIONS`.
+    """
+
+    exts = set(extensions or DEFAULT_EXTENSIONS)
+    if not directory.exists():
+        raise FileNotFoundError(directory)
+
+    aggregated_texts: List[str] = []
+    song_titles: List[str] = []
+
+    for path in sorted(directory.rglob("*")):
+        if path.is_dir():
+            continue
+        if path.suffix.lower() not in exts:
+            continue
+
+        if path.suffix.lower() == ".txt":
+            text = _load_text_file(path)
+        elif path.suffix.lower() == ".json":
+            text = _load_json_file(path)
+        elif path.suffix.lower() == ".csv":
+            text = _load_csv_file(path)
+        else:
+            # Guard for callers that pass custom extension sets.
+            text = _load_text_file(path)
+
+        aggregated_texts.append(text)
+        song_titles.extend(_collect_songs_from_text(text))
+
+    raw_corpus = "\n\n".join(aggregated_texts)
+    normalised_corpus = _normalise_whitespace(raw_corpus)
+    return Corpus(songs=song_titles, text=normalised_corpus)
+
+
+__all__ = ["Corpus", "load_corpus"]

--- a/src/lyrics_service/sentence_generator.py
+++ b/src/lyrics_service/sentence_generator.py
@@ -1,0 +1,105 @@
+"""Sentence generation utilities tailored for Dire Straits inspired text."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Sequence, Tuple
+import random
+import re
+
+
+_TOKEN_PATTERN = re.compile(r"[\w']+|[.!?]")
+
+
+@dataclass
+class MarkovModel:
+    order: int
+    transitions: Dict[Tuple[str, ...], List[str]] = field(default_factory=dict)
+
+    def next_tokens(self, prefix: Tuple[str, ...]) -> List[str]:
+        return self.transitions.get(prefix, [])
+
+
+def tokenise(text: str) -> List[str]:
+    """Tokenise text while keeping punctuation as separate tokens."""
+
+    tokens = _TOKEN_PATTERN.findall(text.lower())
+    return tokens
+
+
+def build_markov_model(text: str, order: int = 2) -> MarkovModel:
+    if order < 1:
+        raise ValueError("order must be >= 1")
+
+    tokens = tokenise(text)
+    transitions: Dict[Tuple[str, ...], List[str]] = defaultdict(list)
+
+    if len(tokens) <= order:
+        return MarkovModel(order=order, transitions={})
+
+    for i in range(len(tokens) - order):
+        prefix = tuple(tokens[i : i + order])
+        suffix = tokens[i + order]
+        transitions[prefix].append(suffix)
+
+    return MarkovModel(order=order, transitions=dict(transitions))
+
+
+def _select_start_prefix(model: MarkovModel) -> Tuple[str, ...]:
+    candidates = [prefix for prefix in model.transitions if prefix[0][0].isalpha()]
+    if not candidates:
+        candidates = list(model.transitions.keys())
+    return random.choice(candidates) if candidates else tuple()
+
+
+def _is_sentence_end(token: str) -> bool:
+    return token in {".", "!", "?"}
+
+
+def generate_sentence(
+    model: MarkovModel,
+    min_tokens: int = 6,
+    max_tokens: int = 40,
+    seed: Tuple[str, ...] | None = None,
+) -> str:
+    """Generate a single sentence using the provided Markov model."""
+
+    if not model.transitions:
+        raise ValueError("model contains no transitions; feed it with lyrics first")
+
+    prefix = seed or _select_start_prefix(model)
+    if not prefix:
+        raise ValueError("unable to determine a start prefix for the sentence")
+
+    generated: List[str] = list(prefix)
+
+    while len(generated) < max_tokens:
+        suffixes = model.next_tokens(tuple(generated[-model.order :]))
+        if not suffixes:
+            break
+        next_token = random.choice(suffixes)
+        generated.append(next_token)
+        if len(generated) >= min_tokens and _is_sentence_end(next_token):
+            break
+
+    sentence = " ".join(_post_process_tokens(generated))
+    return sentence.capitalize()
+
+
+def _post_process_tokens(tokens: Sequence[str]) -> List[str]:
+    """Fix spacing around punctuation."""
+
+    if not tokens:
+        return []
+
+    result: List[str] = []
+    for token in tokens:
+        if token in {".", "!", "?", ","} and result:
+            result[-1] = result[-1] + token
+        else:
+            result.append(token)
+    return result
+
+
+__all__ = ["MarkovModel", "build_markov_model", "generate_sentence", "tokenise"]

--- a/src/lyrics_service/service.py
+++ b/src/lyrics_service/service.py
@@ -1,0 +1,47 @@
+"""High level service orchestrating lyric aggregation and generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+import random
+
+from .corpus_loader import Corpus, load_corpus
+from .sentence_generator import MarkovModel, build_markov_model, generate_sentence
+
+
+@dataclass
+class DireStraitsIdentityService:
+    """Facade combining corpus loading and sentence generation."""
+
+    order: int = 2
+    model: Optional[MarkovModel] = None
+    corpus: Optional[Corpus] = None
+
+    def ingest(self, directory: Path) -> None:
+        """Load a corpus from *directory* and update the Markov model."""
+
+        self.corpus = load_corpus(directory)
+        self.model = build_markov_model(self.corpus.text, order=self.order)
+
+    def ready(self) -> bool:
+        return self.model is not None and bool(self.model.transitions)
+
+    def generate(self, count: int = 1, seed: Optional[int] = None) -> List[str]:
+        """Generate *count* sentences inspired by the Dire Straits corpus."""
+
+        if not self.ready():
+            raise RuntimeError("service is not ready; call ingest() first")
+
+        if seed is not None:
+            random.seed(seed)
+
+        sentences: List[str] = []
+        assert self.model is not None  # for type checkers
+        for _ in range(count):
+            sentences.append(generate_sentence(self.model))
+        return sentences
+
+
+__all__ = ["DireStraitsIdentityService"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_sentence_generator.py
+++ b/tests/test_sentence_generator.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from src.lyrics_service.sentence_generator import build_markov_model, generate_sentence
+
+
+def test_generate_sentence_from_sample_corpus():
+    sample_text = (
+        "Calling Elvis is anybody home. Calling Elvis on the radio. Brothers in arms "
+        "walking down the river. Telegraph road is winding to the sea."
+    )
+    model = build_markov_model(sample_text, order=2)
+    sentence = generate_sentence(model, seed=("calling", "elvis"))
+    assert isinstance(sentence, str)
+    assert sentence
+    assert sentence[0].isupper()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from src.lyrics_service.service import DireStraitsIdentityService
+
+
+@pytest.fixture()
+def sample_corpus(tmp_path: Path) -> Path:
+    text = """# Calling Elvis
+Calling Elvis is anybody home
+
+# Brothers in Arms
+Brothers in arms laying down their lives
+"""
+    corpus_dir = tmp_path / "lyrics"
+    corpus_dir.mkdir()
+    (corpus_dir / "dire_straits.txt").write_text(text, encoding="utf-8")
+    return corpus_dir
+
+
+def test_service_ingest_and_generate(sample_corpus: Path):
+    service = DireStraitsIdentityService(order=2)
+    service.ingest(sample_corpus)
+    assert service.ready()
+    sentences = service.generate(count=2, seed=42)
+    assert len(sentences) == 2
+    assert all(sentence for sentence in sentences)


### PR DESCRIPTION
## Summary
- add a FastAPI application that ingests Dire Straits lyric corpora and exposes sentence generation endpoints
- implement reusable corpus loading, Markov-based generation utilities, and a service façade
- document setup steps, dependencies, and add pytest coverage for the generator and service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4ecec29b88326bbd69952b4e002b5